### PR TITLE
Fix typo in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "`No-std` replacement for `std::io::Read`, `std::io::Write`, and `
 repository = "https://github.com/yatima-inc/bytecursor/"
 homepage = "https://github.com/yatima-inc/bytecursor/"
 readme = "README.md"
-documentation = "https://doc.rs/bytecursor"
+documentation = "https://docs.rs/bytecursor"
 categories = ["no-std"]
 keywords = ["no_std", "io"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Your crate is at the top of the crates.io new crates page but if you click through your docs link is broken, https://crates.io/crates/bytecursor I think it gets pulled in from the Cargo.toml file.